### PR TITLE
docs: mention `jcamp` - a Python library for parsing JCAMP-DX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ JCAMP-DX is the IUPAC standard format family for spectral data exchange. IUPAC a
 
 ## Software
 * [JSmol/JSpecView](https://sourceforge.net/projects/jmol/)
-
+* [jcamp](https://github.com/nzhagen/jcamp/): Python library for parsing JCAMP-DX files


### PR DESCRIPTION
This Python module is suitable for reading JCAMP-DX files. Thus it is probably worth to be mentioned.